### PR TITLE
use our own builder images for gcc and golang

### DIFF
--- a/examples/Dockerfile.c
+++ b/examples/Dockerfile.c
@@ -1,6 +1,6 @@
 ARG BASE=cgr.dev/chainguard/static
 
-FROM gcc:12@sha256:49500bb5341dd34d66330e3c7789a3a8e12e6c5f602879fcb37dc83c147c4880 as build
+FROM --platform=amd64 cgr.dev/chainguard/gcc-glibc@sha256:c94ca43fc6443aaf5b62421ef0e8e49744aecbb6820b1485f387c3925f5bb40d as build
 
 COPY hello.c /hello.c
 RUN cc -static /hello.c -o /hello

--- a/examples/Dockerfile.golang
+++ b/examples/Dockerfile.golang
@@ -1,10 +1,11 @@
 ARG BASE=cgr.dev/chainguard/static
 
-FROM --platform=x86_64 golang:alpine@sha256:f3e683657ddf73726b5717c2ff80cdcd9e9efb7d81f77e4948fada9a10dc7257 AS build
+FROM --platform=amd64 cgr.dev/chainguard/go@sha256:93d0850de1bb7a4313eefd4251eb74f20c421559f26c8817b3663fc734d1153d AS build
 
-COPY main.go /main.go
-RUN CGO_ENABLED=0 go build -o /hello /main.go
+WORKDIR /build
+COPY main.go main.go
+RUN CGO_ENABLED=0 go build -o hello main.go
 
 FROM $BASE
-COPY --from=build /hello /hello
+COPY --from=build /build/hello /hello
 CMD ["/hello"]

--- a/examples/Dockerfile.golang
+++ b/examples/Dockerfile.golang
@@ -4,7 +4,7 @@ FROM --platform=amd64 cgr.dev/chainguard/go@sha256:93d0850de1bb7a4313eefd4251eb7
 
 WORKDIR /build
 COPY main.go main.go
-RUN CGO_ENABLED=0 go build -o hello main.go
+RUN CGO_ENABLED=0 go build -o /build/hello main.go
 
 FROM $BASE
 COPY --from=build /build/hello /hello

--- a/examples/Dockerfile.rust
+++ b/examples/Dockerfile.rust
@@ -1,6 +1,6 @@
 ARG BASE=cgr.dev/chainguard/static
 
-FROM --platform=x86_64 rust:alpine@sha256:3bcdeab61ea4e01db688277c5565b4bfb845293520d3b5eee7e9acf02ad6902b as build
+FROM --platform=amd64 rust:alpine@sha256:3bcdeab61ea4e01db688277c5565b4bfb845293520d3b5eee7e9acf02ad6902b as build
 
 RUN rustup target add x86_64-unknown-linux-musl
 RUN echo 'fn main() { println!("Hello"); }' > hello.rs

--- a/test.sh
+++ b/test.sh
@@ -6,5 +6,5 @@ IMAGE_NAME=${IMAGE_NAME:-"cgr.dev/chainguard/static"}
 
 for lang in c golang rust; do
   docker build --build-arg BASE=${IMAGE_NAME} --tag smoke-test-${lang} --file examples/Dockerfile.${lang} examples
-  docker run smoke-test-${lang}
+  docker run --rm smoke-test-${lang}
 done


### PR DESCRIPTION
Fixes chainguard-images/images#99 

In the go build example I moved into a non-`/` directory (`/build`) since the user didn't have permission to read `/main.go`.